### PR TITLE
Initializing Bio4j TitanDB problem

### DIFF
--- a/distribution/src/main/scala/Bio4jDistribution.scala
+++ b/distribution/src/main/scala/Bio4jDistribution.scala
@@ -14,23 +14,21 @@ object Bio4jDistribution {
 
   case object NCBITaxonomy extends DistributionBundle(
     Bio4jRelease.NCBITaxonomy,
-    new File("/media/ephemeral0/bio4j/taxonomy/")
+    new File("/media/ephemeral0/")
   )
   case object GITaxonomyIndex extends DistributionBundle(
     Bio4jRelease.GITaxonomyIndex,
-    new File("/media/ephemeral0/bio4j/indexed_taxonomy/")
+    new File("/media/ephemeral0/")
   )
 
   case object TestTaxonomy extends Bundle(GITaxonomyIndex :~: ∅) {
     override def install[D <: AnyDistribution](d: D): InstallResults = {
-      try { 
-        val human = GITaxonomyIndex.nodeRetriever.getNCBITaxonByTaxId("9606")
-        println("human.getName: " + human.getName)
-        println("human.getScientificName: " + human.getScientificName)
-        println("human.getComments: " + human.getComments)
-        success("Got the Human taxon!")
-      } catch {
-        case e: Exception => failure(e.toString)
+      {
+        val neandertal = GITaxonomyIndex.nodeRetriever.getNCBITaxonByTaxId("63221")
+        success("Got the " + neandertal.getScientificName + " taxon!")
+      } -&- {
+        val gorilla = GITaxonomyIndex.nodeRetriever.getNCBITaxonByTaxId("9595")
+        success("Got the " + gorilla.getScientificName + " taxon!")
       }
     }
   }

--- a/distribution/src/test/scala/Bio4jDistributionTest.scala
+++ b/distribution/src/test/scala/Bio4jDistributionTest.scala
@@ -13,10 +13,12 @@ import ohnosequences.bio4j.distributions._
 class ApplicationTest extends FunSuite with ParallelTestExecution {
 
   // for running test you need to have this file in your project folder
-  val ec2 = EC2.create(new File("/Users/laughedelic/.ec2/Intercrossing.credentials"))
+  val ec2 = EC2.create(new File("Intercrossing.credentials"))
 
   val dist = Bio4jDistributionDist
   val bundle = Bio4jDistribution.TestTaxonomy
+  // val dist = Bio4jReleaseDist
+  // val bundle = Bio4jRelease.NCBITaxonomy
 
   // def testBundle[B <: AnyBundle : dist.isMember : dist.isInstallable](bundle: B) = {
     test("Apply "+bundle.name+" bundle to an instance"){

--- a/lib/src/main/scala/ReleaseBundle.scala
+++ b/lib/src/main/scala/ReleaseBundle.scala
@@ -35,6 +35,7 @@ abstract class ReleaseBundle[
       try { 
         val s3 = S3.create() // we rely on instance role credentials
         val loader = s3.createLoadingManager()
+        // TODO: controll public/private uploading (so far it's private)
         loader.uploadDirectory(s3address, module.dbLocation, recursively = true)
         success(s"Release ${name} was uploaded to ${s3address}")
       } catch {


### PR DESCRIPTION
I have a problem with the [`DistributionBundle`](https://github.com/ohnosequences/bio4j-scala/blob/master/docs/src/lib/DistributionBundle.md): it cannot initialize titan, because it cannot lock access to the directory with the database. Possibly, it happens, because it writes to this directory (downloads the database) before in the same process.

@pablopareja @eparejatobes do you have any ideas, how can I "free"/release/unlock this file, so that then titan can occupy it?

Here is the stacktrace of the failure: [gist](https://gist.github.com/laughedelic/f82e7d9bf2aea41f522a)
Especially the end:

``` java
Caused by: com.sleepycat.je.EnvironmentLockedException: (JE 5.0.73) 
/media/ephemeral0/bio4j/indexed_taxonomy 
The environment cannot be locked for single writer access. 
ENV_LOCKED: The je.lck file could not be locked. Environment is invalid and must be closed.
```
